### PR TITLE
feat: Fix gallery edit functionality and display timestamps

### DIFF
--- a/admin/admin.js
+++ b/admin/admin.js
@@ -120,4 +120,20 @@ document.addEventListener('DOMContentLoaded', () => {
             e.target.style.display = 'none';
         }
     });
+
+    const galleryEditButtons = document.querySelectorAll('.action-btn.edit');
+    const galleryModal = document.getElementById('gallery-modal');
+    const galleryIdInput = document.getElementById('modal-gallery-id');
+    const galleryAltInput = document.getElementById('modal-gallery-alt');
+
+    galleryEditButtons.forEach(button => {
+        button.addEventListener('click', e => {
+            e.preventDefault();
+            const id = button.dataset.id;
+            const alt = button.dataset.alt;
+            galleryIdInput.value = id;
+            galleryAltInput.value = alt;
+            galleryModal.style.display = 'block';
+        });
+    });
 });

--- a/admin/bookings.php
+++ b/admin/bookings.php
@@ -28,6 +28,7 @@
                 <td><?php echo $row['email']; ?></td>
                 <td><?php echo $row['message']; ?></td>
                 <td><?php echo $row['status']; ?></td>
+                <td><?php echo date('Y-m-d h:i:s A', $row['timestamp']); ?></td>
                 <td>
                     <a href="dashboard.php?page=bookings&action=accept&id=<?php echo $row['id']; ?>" class="action-btn accept">Accept</a>
                     <a href="dashboard.php?page=bookings&action=reject&id=<?php echo $row['id']; ?>" class="action-btn reject">Reject</a>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -77,6 +77,32 @@ if (isset($_POST['save_event'])) {
     exit;
 }
 
+if (isset($_POST['edit_gallery'])) {
+    $id = $_POST['id'];
+    $alt_text = $_POST['alt_text'];
+    $image = $_FILES['image']['name'];
+
+    if (empty($image)) {
+        $query = "UPDATE gallery SET alt_text = '$alt_text', timestamp = '" . time() . "' WHERE id = $id";
+        mysqli_query($conn, $query);
+    } else {
+        $target = "../images/apps/silver_gallery/" . basename($image);
+        $img_location = "images/apps/silver_gallery/" . basename($image);
+
+        $query = "UPDATE gallery SET img_location = '$img_location', alt_text = '$alt_text', timestamp = '" . time() . "' WHERE id = $id";
+        mysqli_query($conn, $query);
+
+        if (move_uploaded_file($_FILES['image']['tmp_name'], $target)) {
+            // success
+        } else {
+            $msg = "Failed to upload image";
+        }
+    }
+
+    header('Location: dashboard.php?page=gallery');
+    exit;
+}
+
 if (isset($_POST['edit_alt'])) {
     $id = $_POST['id'];
     $alt_text = $_POST['alt_text'];
@@ -242,6 +268,25 @@ if (isset($_GET['page']) && $_GET['page'] == 'bookings' && isset($_GET['action']
                     <input type="email" name="email" id="modal-email" required>
                 </div>
                 <button type="submit" name="save_event">Save Event</button>
+            </form>
+        </div>
+    </div>
+
+    <div id="gallery-modal" class="modal">
+        <div class="modal-content">
+            <span class="close-btn">&times;</span>
+            <h2>Edit Gallery Item</h2>
+            <form action="dashboard.php?page=gallery&action=edit" method="post" enctype="multipart/form-data">
+                <input type="hidden" name="id" id="modal-gallery-id">
+                <div class="input-group">
+                    <label for="modal-gallery-image">Image</label>
+                    <input type="file" name="image" id="modal-gallery-image">
+                </div>
+                <div class="input-group">
+                    <label for="modal-gallery-alt">Alt Text</label>
+                    <input type="text" name="alt_text" id="modal-gallery-alt" required>
+                </div>
+                <button type="submit" name="edit_gallery">Save Changes</button>
             </form>
         </div>
     </div>

--- a/admin/gallery.php
+++ b/admin/gallery.php
@@ -7,11 +7,8 @@
     ?>
         <div class="gallery-item">
             <img src="../<?php echo $row['img_location']; ?>" alt="<?php echo $row['alt_text']; ?>">
-            <form action="dashboard.php?page=gallery&action=edit" method="post">
-                <input type="hidden" name="id" value="<?php echo $row['id']; ?>">
-                <input type="text" name="alt_text" value="<?php echo $row['alt_text']; ?>">
-                <button type="submit" name="edit_alt" class="action-btn edit">Edit</button>
-            </form>
+            <p><?php echo date('Y-m-d h:i:s A', $row['timestamp']); ?></p>
+            <a href="#" class="action-btn edit" data-id="<?php echo $row['id']; ?>" data-alt="<?php echo $row['alt_text']; ?>">Edit</a>
             <a href="dashboard.php?page=gallery&action=delete&id=<?php echo $row['id']; ?>" class="action-btn delete">Delete</a>
         </div>
     <?php } ?>

--- a/admin/liquor_orders.php
+++ b/admin/liquor_orders.php
@@ -24,9 +24,10 @@
                 <td><?php echo $row['quantity']; ?></td>
                 <td><?php echo $row['message']; ?></td>
                 <td><?php echo $row['status']; ?></td>
+                <td><?php echo date('Y-m-d h:i:s A', $row['timestamp']); ?></td>
                 <td>
-                    <a href="dashboard.php?page=liquor_orders&action=accept&id=<?php echo $row['id']; ?>">Accept</a>
-                    <a href="dashboard.php?page=liquor_orders&action=reject&id=<?php echo $row['id']; ?>">Reject</a>
+                    <a href="dashboard.php?page=liquor_orders&action=accept&id=<?php echo $row['id']; ?>" class="action-btn accept">Accept</a>
+                    <a href="dashboard.php?page=liquor_orders&action=reject&id=<?php echo $row['id']; ?>" class="action-btn reject">Reject</a>
                 </td>
             </tr>
         <?php } ?>

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -24,7 +24,7 @@
                 <td><?php echo $row['email']; ?></td>
                 <td><?php echo $row['subject']; ?></td>
                 <td><?php echo $row['message']; ?></td>
-                <td><?php echo date('Y-m-d H:i:s', $row['timestamp']); ?></td>
+                <td><?php echo date('Y-m-d h:i:s A', $row['timestamp']); ?></td>
                 <td><?php echo $row['status']; ?></td>
                 <td>
                     <a href="dashboard.php?page=messages&action=archive&id=<?php echo $row['id']; ?>" class="action-btn archive">Archive</a>


### PR DESCRIPTION
This commit fixes the gallery edit functionality and displays the timestamps for all records in the UI.

The following changes were made:
- Created a modal for editing gallery items, allowing you to change the image and alt text.
- Displayed the last uploaded/modified time for each image in the gallery.
- Displayed the date and time for all records in the messages, bookings, and liquor orders sections.